### PR TITLE
Added matching text-xs to _links.html

### DIFF
--- a/allauth_ui/templates/account/_links.html
+++ b/allauth_ui/templates/account/_links.html
@@ -1,4 +1,4 @@
-<div class="flex justify-center mt-6">
+<div class="flex justify-center mt-6 text-xs">
   <a class="text-blue-400 hover:text-blue-500" href="/">Home</a>
   <span class="mx-2 text-gray-300">/</span>
   <a class="text-blue-400 hover:text-blue-500" href="{% url 'account_login' %}">Log In</a>


### PR DESCRIPTION
The visuals on pages with `_links.html` were inconsistent with others. This change makes them consistent.

Aside: Have we considered building common CSS classes to reuse? It seems like it'd reduce/remove duplication issues like this =/

In this PR:

- Added `text-xs` to `_links.html`

**Screenshots:**

Sign in page (no change, but for reference):

![image](https://github.com/danihodovic/django-allauth-ui/assets/902488/0b4c4fd1-604c-476f-9295-1f6673137e87)

Forgot password (before):

![image](https://github.com/danihodovic/django-allauth-ui/assets/902488/e822e9ea-a984-459e-9232-2753bfc8db25)

Forgot password (after):

![image](https://github.com/danihodovic/django-allauth-ui/assets/902488/56e03e82-5152-40dd-8af9-153fea810aa9)