### PR TITLE
Add signup_closed, for when adaptor disallows signup

### DIFF
--- a/allauth_ui/templates/account/signup_closed.html
+++ b/allauth_ui/templates/account/signup_closed.html
@@ -1,0 +1,14 @@
+{% extends "account/base.html" %}
+{% load i18n %}
+{% load allauth %}
+
+{% block head_title %}{% trans "Sign Up Closed" %}{% endblock head_title %}
+{% block content %}
+<div class="flex flex-col items-center justify-center w-screen h-screen text-gray-700 bg-gray-200">
+  <div class="flex flex-col items-center p-12 bg-white rounded shadow-lg md:w-7/12 xl:w-5/12">
+    <h1 class="mb-5 text-3xl text-center">{% trans "Sign Up Closed" %}</h1>
+    <p class="my-5">{% trans "We are sorry, but the sign up is currently closed." %}</p>
+    {% include "account/_links.html" %}
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Super helpful project, thanks for sharing!

This template comes into play if a custom adaptor is used to disallow manual signup, e.g.

    # adapters.py
    from allauth.account.adapter import DefaultAccountAdapter
    from allauth.socialaccount.adapter import DefaultSocialAccountAdapter

    class CustomAccountAdapter(DefaultAccountAdapter):
        def is_open_for_signup(self, request):
            return False

    class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
        def is_open_for_signup(self, request, sociallogin):
            return True

    # settings.py
    ACCOUNT_ADAPTER = 'myproject.myapp.adapter.CustomAccountAdapter'
    SOCIALACCOUNT_ADAPTER = 'myproject.myapp.adapter.CustomSocialAccountAdapter'

For the above, signup using configured social accounts would be allowed, but manual signup would be disallowed and clicking 'signup' on any page would display the template included in this pull request (handled by django-allauth automatically based on the return value of is_open_for_signup).