### PR TITLE
fix: missing % for logout.html

### DIFF
--- a/allauth_ui/templates/account/logout.html
+++ b/allauth_ui/templates/account/logout.html
@@ -7,7 +7,7 @@
     <form method="post" action="{% url 'account_logout' %}">
         {% csrf_token %}
         <p>{% translate "Are you sure you want to sign out?" %}</p>
-        {% translate "Sign out" as signout_message }
+        {% translate "Sign out" as signout_message %}
         {% include "account/_button.html" with text=signout_message %}
     </form>
 {% endblock %}


### PR DESCRIPTION
**Before**

<img width="446" alt="스크린샷 2024-06-05 11 05 05" src="https://github.com/danihodovic/django-allauth-ui/assets/37995997/0ff8d53f-3e84-4c21-870b-fe22f10a5de8">

**After**

<img width="369" alt="스크린샷 2024-06-05 11 50 09" src="https://github.com/danihodovic/django-allauth-ui/assets/37995997/fd928f2b-61d5-43d9-b57d-dd62a49660d7">
