### PR TITLE
fix: Revert "build: add pre-build step to compile css (#77)"

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,9 +1,0 @@
-import subprocess
-
-
-def compile_tailwind():
-    subprocess.run(["npm", "run-script", "build"], check=True)
-
-
-if __name__ == "__main__":
-    compile_tailwind()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,6 @@ classifiers = [
 	"Topic :: System :: Systems Administration :: Authentication/Directory",
 ]
 
-[tool.poetry.build]
-generate-setup-file = false
-script = "build.py"
-
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0.0"
 django-widget-tweaks = "^1.5.0"


### PR DESCRIPTION
This reverts commit 0b28f0c3f42731f10833062d1379090f67ffea32.

New installs fail with: "not supporting PEP 517 builds"