### PR TITLE
fix: link text of menu links for dark themes

### DIFF
--- a/allauth_ui/templates/allauth/layouts/base.html
+++ b/allauth_ui/templates/allauth/layouts/base.html
@@ -26,7 +26,7 @@
             {% endif %}
             {% block content %}
             {% endblock content %}
-            <div class="mx-auto text-neutral [&_a]:link text-sm flex flex-col md:flex-row items-center justify-center gap-3 mt-3">
+            <div class="mx-auto [&_a]:link text-sm flex flex-col md:flex-row items-center justify-center gap-3 mt-3">
                 {% if user.is_authenticated %}
                     {% url 'account_email' as email_url %}
                     {% if email_url %}

--- a/sample_deployment/sample_deployment/settings.py
+++ b/sample_deployment/sample_deployment/settings.py
@@ -183,3 +183,5 @@ STORAGES = {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
 }
+
+ALLAUTH_UI_THEME = "business"


### PR DESCRIPTION
text-neutral is not visible on dark themes. Let DaisyUI handle it.