### PR TITLE
fix: /accounts/3rdparty by loading slippers tags

### DIFF
--- a/allauth_ui/templates/socialaccount/connections.html
+++ b/allauth_ui/templates/socialaccount/connections.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load allauth_ui %}
 {% load widget_tweaks %}
+{% load slippers %}
 {% block content %}
     {% trans "Account Connections" as heading %}
     {% if form.accounts %}


### PR DESCRIPTION
> django.template.exceptions.TemplateSyntaxError: Invalid block tag on
> line 21: 'var', expected 'empty' or 'endfor'.

Fixes #100