### PR TITLE
Long emails in the account/email template extend beyond their containers

### DIFF
--- a/allauth_ui/templates/account/email.html
+++ b/allauth_ui/templates/account/email.html
@@ -56,8 +56,10 @@
         <h2 class="py-3 text-lg">{% trans "Add Email Address" %}</h2>
         {% trans "Add Email" as button_text %}
         {% #form form=form url=action_url button_text=button_text use_default_button="false" %}
-            {% csrf_token %}
-            <button type="submit" name="action_add" class="my-3 btn">{{ button_text }}</button>
+        {% csrf_token %}
+        <button type="submit" name="action_add" class="my-3 btn">
+            {{ button_text }}
+        </button>
         {% /form %}
     {% endif %}
     {% /container %}

--- a/allauth_ui/templates/account/email.html
+++ b/allauth_ui/templates/account/email.html
@@ -16,8 +16,8 @@
             {% for radio in emailaddress_radios %}
                 {% with emailaddress=radio.emailaddress %}
                     <div class="form-control">
-                        <label class="cursor-pointer label border p-3 rounded">
-                            <span class="label-text">{{ emailaddress.email }}
+                        <label class="flex gap-3 cursor-pointer label border rounded px-3">
+                            <span class="grow label-text overflow-auto py-3">{{ emailaddress.email }}
                                 {% if emailaddress.verified %}
                                     <div class="badge badge-primary badge-outline">{% trans "verified" %}</div>
                                 {% endif %}

--- a/allauth_ui/templates/account/login.html
+++ b/allauth_ui/templates/account/login.html
@@ -13,12 +13,12 @@
         {% url 'account_login' as action_url %}
         {% #form form=form url=action_url button_text=heading %}
         {% if form.remember %}
-        <div class="items-start my-2 form-control">
-            <label class="cursor-pointer label">
-                {% render_field form.remember class="checkbox checkbox-accent" %}
-                <span class="ml-2 label-text">{% trans "Remember me" %}</span>
-            </label>
-        </div>
+            <div class="items-start my-2 form-control">
+                <label class="cursor-pointer label">
+                    {% render_field form.remember class="checkbox checkbox-accent" %}
+                    <span class="ml-2 label-text">{% trans "Remember me" %}</span>
+                </label>
+            </div>
         {% endif %}
         {{ redirect_field }}
         {% csrf_token %}


### PR DESCRIPTION
Hi all!
This PR fixes a small overflow issue within the allauth account/email template. Currently, if the screen is small enough and an email is long enough, the email text extends beyond its container. My changes ensure that long emails scroll horizontally instead.