### PR TITLE
Fix: Include compiled translation files (.mo) in package distribution

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,9 @@ jobs:
           python-version: 3.11
 
       - name: Install GNU gettext
-        run: sudo apt-get install -y gettext
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -117,3 +119,69 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest tests
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build CSS
+        run: npm run build
+
+      - uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: 3.11
+
+      - name: Install GNU gettext
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: |
+          poetry install --no-interaction --no-root
+
+      - name: Compile messages
+        run: |
+          source .venv/bin/activate
+          ./manage.py compilemessages
+
+      - name: Build package
+        run: |
+          poetry build
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-packages
+          path: dist/

--- a/allauth_ui/templates/account/confirm_login_code.html
+++ b/allauth_ui/templates/account/confirm_login_code.html
@@ -7,7 +7,9 @@
 {% block content %}
     {% trans "Sign In" as heading %}
     {% #container heading=heading  %}
-    <div class="py-3">{% blocktranslate %}Enter Sign-In Code{% endblocktranslate %}</div>
+    <div class="py-3">
+        {% blocktranslate %}Enter Sign-In Code{% endblocktranslate %}
+    </div>
     <div class="py-3">
         {% setvar email_link %}
         <a href="mailto:{{ email }}">{{ email }}</a>
@@ -19,7 +21,9 @@
 {{ redirect_field }}
 {% csrf_token %}
 {% /form %}
-<button type="submit" class="btn btn-red" form="logout-from-stage">{% translate "Cancel" %}</button>
+<button type="submit" class="btn btn-red" form="logout-from-stage">
+    {% translate "Cancel" %}
+</button>
 <form id="logout-from-stage"
       method="post"
       action="{% url 'account_logout' %}">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ packages = [
     { include = "allauth_ui" },
 ]
 include = [
-  {path = "allauth_ui/static/allauth_ui/output.css", format = ["sdist", "wheel"]}
+  {path = "allauth_ui/static/allauth_ui/output.css", format = ["sdist", "wheel"]},
+  {path = "allauth_ui/locale/*/LC_MESSAGES/*.mo", format = ["sdist", "wheel"]}
 ]
 readme = "README.md"
 repository = "https://github.com/danihodovic/django-allauth-ui"


### PR DESCRIPTION
## Problem
Translation files are not working when the package is installed from PyPI because compiled message files (`.mo`) are not included in the distributed package. Only the source `.po` files are present in the repository.

## Solution
This PR fixes the issue by:

1. **Added `compilemessages` step** in the build workflow to generate `.mo` files before packaging
2. **Updated `pyproject.toml`** to include `.mo` files in both sdist and wheel distributions
3. **Updated `allauth_ui/templates/account/confirm_login_code.html`** to fix a style issue reported by `djlint`

## Changes
- Modified `.github/workflows/ci-cd.yml`:
  - Added build job
  - Added `compilemessages`
  - Added artifacts upload for package inspection
- Modified `pyproject.toml`:
  - Added `.mo` files to the `include` configuration
- Modified `allauth_ui/templates/account/confirm_login_code.html`
  - Fix style problem reported by djlint

## Testing
- ✅ Build workflow completes successfully
- ✅ `.mo` files are present in both wheel and sdist packages (verified via artifact inspection)
- ✅ All existing lint and test jobs pass

## Optional Enhancement
I can also add a `publish-pypi` job that automatically publishes to PyPI on tagged releases, if desired. Let me know if you'd like me to include that in this PR.

## Related Issue
Fixes danihodovic/django-allauth-ui#153